### PR TITLE
Add display block to canvas to avoid infinite resizing

### DIFF
--- a/Web/3DObject/src/package.xml
+++ b/Web/3DObject/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="WebXR3DObject" version="1.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="WebXR3DObject" version="0.0.2" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="WebXR3DObject.xml" />
         </widgetFiles>

--- a/Web/Container/src/WebXRContainer.tsx
+++ b/Web/Container/src/WebXRContainer.tsx
@@ -144,7 +144,9 @@ export function WebXRContainer(props: WebXRContainerContainerProps): ReactElemen
         >
             <div id="reader" />
             <ParentContext.Provider value={parentID}>{props.mxContentWidget}</ParentContext.Provider>
-            <canvas ref={canvasRef} style={{ width: "100%", height: "100%", display: "block" }} />
+            <div style={{ flex: 1, ...props.style }}>
+                <canvas ref={canvasRef} style={{ width: "100%", height: "100%", display: "block" }} />
+            </div>
         </EngineContext.Provider>
     );
 }

--- a/Web/Container/src/WebXRContainer.tsx
+++ b/Web/Container/src/WebXRContainer.tsx
@@ -144,8 +144,8 @@ export function WebXRContainer(props: WebXRContainerContainerProps): ReactElemen
         >
             <div id="reader" />
             <ParentContext.Provider value={parentID}>{props.mxContentWidget}</ParentContext.Provider>
-            <div style={{ flex: 1, ...props.style }}>
-                <canvas ref={canvasRef} style={{ width: "100%", height: "100%", display: "block" }} />
+            <div style={{ flex: 1 }}>
+                <canvas ref={canvasRef} style={{ width: "100%", height: "100%", display: "block", ...props.style }} />
             </div>
         </EngineContext.Provider>
     );

--- a/Web/Container/src/WebXRContainer.tsx
+++ b/Web/Container/src/WebXRContainer.tsx
@@ -144,7 +144,7 @@ export function WebXRContainer(props: WebXRContainerContainerProps): ReactElemen
         >
             <div id="reader" />
             <ParentContext.Provider value={parentID}>{props.mxContentWidget}</ParentContext.Provider>
-            <canvas ref={canvasRef} style={{ width: "100%", height: "100%" }} />
+            <canvas ref={canvasRef} style={{ width: "100%", height: "100%", display: "block" }} />
         </EngineContext.Provider>
     );
 }

--- a/Web/Container/src/package.xml
+++ b/Web/Container/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="WebXRContainer" version="1.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="WebXRContainer" version="0.0.2" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="WebXRContainer.xml" />
         </widgetFiles>

--- a/Web/Cube/src/package.xml
+++ b/Web/Cube/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="WebXRCube" version="1.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="WebXRCube" version="0.0.2" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="WebXRCube.xml" />
         </widgetFiles>

--- a/Web/ImageTracker/src/package.xml
+++ b/Web/ImageTracker/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="WebXRImageTracker" version="1.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="WebXRImageTracker" version="0.0.2" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="WebXRImageTracker.xml" />
         </widgetFiles>

--- a/Web/Node/src/package.xml
+++ b/Web/Node/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="WebXRNode" version="1.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="WebXRNode" version="0.0.2" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="WebXRNode.xml" />
         </widgetFiles>

--- a/Web/Repeater/src/package.xml
+++ b/Web/Repeater/src/package.xml
@@ -2,7 +2,7 @@
 <package xmlns="http://www.mendix.com/package/1.0/">
     <clientModule
     name="WebXRRepeater"
-    version="1.0.0"
+    version="0.0.2"
     xmlns="http://www.mendix.com/clientModule/1.0/"
   >
         <widgetFiles>

--- a/Web/Sphere/src/package.xml
+++ b/Web/Sphere/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="WebXRSphere" version="1.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="WebXRSphere" version="0.0.2" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="WebXRSphere.xml" />
         </widgetFiles>

--- a/Web/Square/src/package.xml
+++ b/Web/Square/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="WebXRSquare" version="1.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="WebXRSquare" version="0.0.2" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="WebXRSquare.xml" />
         </widgetFiles>

--- a/Web/Text/src/package.xml
+++ b/Web/Text/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="WebXRText" version="1.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="WebXRText" version="0.0.2" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="WebXRText.xml" />
         </widgetFiles>


### PR DESCRIPTION
An issue was discovered that caused infinite resizing when using the webxr container widget in a layout container. To fix this `display: block` was added to the canvas element in the container widget. By default this is set to inline. 